### PR TITLE
Allocate bitmap from caller, test program output larger bitmap

### DIFF
--- a/main.c
+++ b/main.c
@@ -128,10 +128,8 @@ void main(int argc, char **argv)
 
   // generate a msdf bitmap
   // ideally you would do this in your shader
-  float *msdf = malloc(sizeof(float)*3*size_sdf*size_sdf);
-  memset(msdf, 0.0f, sizeof(float)*3*size_sdf*size_sdf);
   ex_metrics_t metrics;
-  ex_msdf_glyph(&font, ex_utf8(c), size_sdf, size_sdf, msdf, &metrics, 1);
+  float *msdf = ex_msdf_glyph(&font, ex_utf8(c), size_sdf, size_sdf, &metrics, 1);
   uint8_t *bitmap_sdf = malloc(3*size_sdf *size_sdf);
   memset(bitmap_sdf, 0, 3*size_sdf *size_sdf);
   for (int y = 0; y < size_sdf; y++) {

--- a/msdf.c
+++ b/msdf.c
@@ -700,7 +700,7 @@ double shoelace(const vec2 a, const vec2 b)
   return (b[0]-a[0])*(a[1]+b[1]);
 }
 
-int ex_msdf_glyph(stbtt_fontinfo *font, uint32_t c, size_t w, size_t h, float *bitmap, ex_metrics_t *metrics, int autofit)
+int ex_msdf_glyph_mem(stbtt_fontinfo *font, uint32_t c, size_t w, size_t h, float *bitmap, ex_metrics_t *metrics, int autofit)
 {
   // Funit to pixel scale
   float scale = stbtt_ScaleForMappingEmToPixels(font, h);
@@ -1164,9 +1164,9 @@ int ex_msdf_glyph(stbtt_fontinfo *font, uint32_t c, size_t w, size_t h, float *b
   for (int y=0; y<h; y++) {
     for (int x=0; x<w; x++) {
       if ((x > 0  && pixel_clash(P(x, y, w, bitmap), P(MAX(x-1, 0), y, w, bitmap), tx))
-      || (x < w-1 && pixel_clash(P(x, y, w, bitmap), P(MIN(x+1, w), y, w, bitmap), tx))
+      || (x < w-1 && pixel_clash(P(x, y, w, bitmap), P(MIN(x+1, w-1), y, w, bitmap), tx))
       || (y > 0   && pixel_clash(P(x, y, w, bitmap), P(x, MAX(y-1, 0), w, bitmap), ty))
-      || (y < h-1 && pixel_clash(P(x, y, w, bitmap), P(x, MIN(y+1, h), w, bitmap), ty))
+      || (y < h-1 && pixel_clash(P(x, y, w, bitmap), P(x, MIN(y+1, h-1), w, bitmap), ty))
         ) {
           clashes[cindex].x   = x;
           clashes[cindex++].y = y;
@@ -1184,4 +1184,15 @@ int ex_msdf_glyph(stbtt_fontinfo *font, uint32_t c, size_t w, size_t h, float *b
   free(clashes);
 
   return 1;
+}
+
+float *ex_msdf_glyph(stbtt_fontinfo *font, uint32_t c, size_t w, size_t h, ex_metrics_t *metrics, int autofit)
+{
+  float *bitmap = malloc(sizeof(float)*3*w*h);
+  memset(bitmap, 0.0f, sizeof(float)*3*w*h);
+  if (ex_msdf_glyph_mem(font, c, w, h, bitmap, metrics, autofit) != 1) {
+    free(bitmap);
+    return NULL;
+  }
+  return bitmap;
 }

--- a/msdf.h
+++ b/msdf.h
@@ -43,7 +43,8 @@ typedef struct {
   Bitmap is a 3-channel float array (3*w*h)
   Returned result is 1 for success or 0 in case of an error
  */
-int ex_msdf_glyph(stbtt_fontinfo *font, uint32_t c, size_t w, size_t h, float *bitmap, ex_metrics_t *metrics, int autofit);
+int ex_msdf_glyph_mem(stbtt_fontinfo *font, uint32_t c, size_t w, size_t h, float *bitmap, ex_metrics_t *metrics, int autofit);
+float *ex_msdf_glyph(stbtt_fontinfo *font, uint32_t c, size_t w, size_t h, ex_metrics_t *metrics, int autofit);
 
 static inline uint32_t ex_utf8(const char *c) {
   uint32_t val = 0;

--- a/msdf.h
+++ b/msdf.h
@@ -1,6 +1,7 @@
 /* msdf
   Handles multi-channel signed distance field bitmap
   generation from given ttf (stb_truetype.h) font.
+  https://github.com/exezin/msdf-c
 
   Depends on stb_truetype.h to load the ttf file.
 
@@ -26,6 +27,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+	
 typedef struct {
   int left_bearing;
   int advance;
@@ -36,8 +41,9 @@ typedef struct {
 /*
   Generates a bitmap from the specified character (c)
   Bitmap is a 3-channel float array (3*w*h)
+  Returned result is 1 for success or 0 in case of an error
  */
-float* ex_msdf_glyph(stbtt_fontinfo *font, uint32_t c, size_t w, size_t h, ex_metrics_t *metrics, int autofit);
+int ex_msdf_glyph(stbtt_fontinfo *font, uint32_t c, size_t w, size_t h, float *bitmap, ex_metrics_t *metrics, int autofit);
 
 static inline uint32_t ex_utf8(const char *c) {
   uint32_t val = 0;
@@ -67,5 +73,9 @@ static inline uint32_t ex_utf8(const char *c) {
 
   return val;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // EX_MSDF_H


### PR DESCRIPTION
The test program now generates the sdf image and bitmap software render at two seperate resolutions. For the software rendered bitmap I implemented a simple bi-linear interpolation of the source msdf texture. I set `size_sdf` to 26 for my testing, maybe these sizes should be arguments? 

`ex_msdf_glyph_mem()` takes a bitmap pointer that is allocated by the caller, `ex_msdf_glyph()` keeps the existing API. In my program I wanted to allocate a single CPU side bitmap and copy to OpenGL between calls.

I made a small modification to clashes to prevent reading out of bitmaps bounds, the extsing bound checks did not prevent errors on my system.

![msdf_glyph](https://user-images.githubusercontent.com/4019937/81972129-c4cd6300-95e7-11ea-9de7-297365e468de.png)
![glyph](https://user-images.githubusercontent.com/4019937/81972128-c434cc80-95e7-11ea-8b28-e9525433f2a3.png)

